### PR TITLE
Implement multi-horizon event-driven backtester scaffold

### DIFF
--- a/backtester/backtest_multi_horizon.py
+++ b/backtester/backtest_multi_horizon.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+"""Event driven multi‑horizon backtester.
+
+The implementation is intentionally compact – it does not aim to be a production
+grade trading system but rather a faithful, reproducible scaffold that mirrors
+live behaviour.  The module wires together the surrounding helpers in this
+package and follows the blueprint provided in the task description.
+"""
+
+import argparse
+import os
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from . import execution_sim, metrics, ohlc, portfolio, risk, signals, utils
+
+
+def run_backtest(cfg: Dict, results_dir: str) -> None:
+    utils.ensure_dir(results_dir)
+    logger = utils.get_logger("backtest", os.path.join(results_dir, "backtest.log"))
+    utils.seed_everything(cfg.get("seed", 42))
+
+    all_trade_returns: List[pd.Series] = []
+
+    for symbol in cfg["data"]["symbols"]:
+        logger.info(f"Loading ticks for {symbol}")
+        ticks = ohlc.load_ticks(symbol, cfg["data"]["months"], cfg["data"]["dir"])
+        bars_1m = ohlc.build_ohlcv(ticks)
+        bars_15m = ohlc.resample_from_1m(bars_1m, cfg["horizons"]["micro"])
+        bars_60m = ohlc.resample_from_1m(bars_1m, cfg["horizons"]["macro"])
+        bars_4h = ohlc.resample_from_1m(bars_1m, "240T")
+        bars_1d = ohlc.resample_from_1m(bars_1m, cfg["horizons"]["daily"])
+
+        atr_series = risk.atr(bars_1m, cfg["risk"]["atr_period"])
+        don = signals.donchian(bars_1m, cfg["signals"]["trigger"]["donchian_lookback"])
+        comp = signals.compression(bars_1m, cfg["signals"]["compression"])
+        micro = signals.micro_slope(bars_1m.index, bars_15m, cfg["signals"]["micro"])
+        macro = signals.macro_regime(bars_1m.index, bars_60m, bars_4h, bars_1d, cfg["signals"]["regime"])
+        returns_1m = np.log(bars_1m["close"] / bars_1m["close"].shift(1))
+        sigma = portfolio.vol_forecast(returns_1m, cfg["sizing"])
+
+        feat = pd.DataFrame({
+            "open": bars_1m["open"],
+            "high": bars_1m["high"],
+            "low": bars_1m["low"],
+            "close": bars_1m["close"],
+            "atr": atr_series,
+            "don_high": don["high"],
+            "don_low": don["low"],
+            "compression": comp,
+            "micro": micro,
+            "macro": macro,
+            "sigma": sigma,
+        }).dropna()
+
+        if feat.empty:
+            utils.write_advisory(os.path.join(results_dir, "advisory.txt"), f"No data for {symbol}")
+            continue
+
+        t0 = feat.index[0]
+        warmup_end = t0 - pd.Timedelta(minutes=1)
+        logger.info(
+            f"{symbol}: Warm-up complete at {warmup_end}. Daily bars: {len(bars_1d[bars_1d.index<=warmup_end])}. First tradable 1m: {t0}."
+        )
+
+        sym_dir = os.path.join(results_dir, symbol)
+        utils.ensure_dir(sym_dir)
+
+        pos: risk.Position | None = None
+        trades = []
+        equity = []
+        pnl = 0.0
+        consecutive_losses = 0
+        cooldown = 0
+        daily_start = t0.normalize()
+        daily_pnl = 0.0
+
+        for ts in feat.index[feat.index >= t0]:
+            row = feat.loc[ts]
+            if ts.normalize() > daily_start:
+                daily_start = ts.normalize()
+                daily_pnl = 0.0
+
+            if pos is None:
+                allow_entry = daily_pnl > -cfg["risk"]["daily_loss_limit_pct"] / 100 * max(abs(pnl), 1.0)
+                allow_entry &= cooldown == 0
+                if allow_entry:
+                    prev_close = feat["close"].shift(1).loc[ts]
+                    long_trig = (
+                        row["macro"] > 0
+                        and row["micro"] > cfg["signals"]["micro"].get("min_slope_long", 0.0)
+                        and row["compression"]
+                        and prev_close <= row["don_high"]
+                        and row["close"] > row["don_high"]
+                    )
+                    short_trig = (
+                        row["macro"] < 0
+                        and row["micro"] < cfg["signals"]["micro"].get("max_slope_short", 0.0)
+                        and row["compression"]
+                        and prev_close >= row["don_low"]
+                        and row["close"] < row["don_low"]
+                    )
+                    side = 1 if long_trig else -1 if short_trig else 0
+                    if side != 0:
+                        # next bar open
+                        idx = feat.index.get_loc(ts) + 1
+                        if idx < len(feat.index):
+                            next_ts = feat.index[idx]
+                            next_row = feat.iloc[idx]
+                            price = next_row["open"]
+                            atr_val = next_row["atr"]
+                            sigma_val = next_row["sigma"]
+                            notional = portfolio.position_notional(price, sigma_val, cfg["sizing"])
+                            qty = notional / price * side
+                            fill_price, fee = execution_sim.simulate_fill(
+                                price, abs(qty), side, atr_val, cfg["costs"]
+                            )
+                            sl, tp = risk.initial_sl_tp(fill_price, atr_val, side, cfg["risk"])
+                            pos = risk.Position(side=side, qty=qty, entry_price=fill_price, sl=sl, tp=tp)
+                            trades.append(
+                                {
+                                    "symbol": symbol,
+                                    "entry_ts": next_ts,
+                                    "side": "LONG" if side == 1 else "SHORT",
+                                    "qty": qty,
+                                    "entry_price": fill_price,
+                                    "fee_entry": fee,
+                                }
+                            )
+            else:
+                risk.maybe_move_be(pos, row["close"], cfg["risk"])
+                risk.maybe_trail(pos, row["atr"], row["close"], cfg["risk"])
+                exit_price = risk.check_exit(pos, row)
+                if exit_price is not None:
+                    fill_price, fee = execution_sim.simulate_fill(
+                        exit_price, abs(pos.qty), -pos.side, row["atr"], cfg["costs"]
+                    )
+                    pnl_trade = (fill_price - pos.entry_price) * pos.qty - fee
+                    pnl += pnl_trade
+                    daily_pnl += pnl_trade
+                    trades[-1].update(
+                        {
+                            "exit_ts": ts,
+                            "exit_price": fill_price,
+                            "pnl": pnl_trade,
+                            "fee_exit": fee,
+                        }
+                    )
+                    if pnl_trade < 0:
+                        consecutive_losses += 1
+                        if consecutive_losses >= cfg["risk"].get("cooldown_losses", 3):
+                            cooldown = cfg["risk"].get("cooldown_losses", 3)
+                            consecutive_losses = 0
+                    else:
+                        consecutive_losses = 0
+                    pos = None
+            if cooldown > 0:
+                cooldown -= 1
+            equity.append({"ts": ts, "equity": pnl})
+
+        trades_df = pd.DataFrame(trades)
+        equity_df = pd.DataFrame(equity)
+        if not trades_df.empty:
+            trades_df.to_csv(os.path.join(sym_dir, "trades.csv"), index=False)
+            trade_returns = trades_df["pnl"] / trades_df["entry_price"].abs()
+            all_trade_returns.append(trade_returns)
+        else:
+            utils.write_advisory(
+                os.path.join(sym_dir, "advisory.txt"), f"No trades generated for {symbol}"
+            )
+        if not equity_df.empty:
+            equity_df.to_csv(os.path.join(sym_dir, "equity_curve.csv"), index=False)
+
+    if all_trade_returns:
+        returns = pd.concat(all_trade_returns, ignore_index=True)
+        summary = metrics.compute_kpis(returns)
+        pd.DataFrame([summary]).to_csv(
+            os.path.join(results_dir, "summary.csv"), index=False
+        )
+        metrics_json = metrics.compute_kpis(returns)
+        with open(os.path.join(results_dir, "metrics.json"), "w", encoding="utf-8") as f:
+            import json
+
+            json.dump(metrics_json, f, indent=2)
+        boot = metrics.run_bootstrap_envelopes(returns.values)
+        pd.DataFrame(boot).to_csv(
+            os.path.join(results_dir, "bootstrap_envelope.csv"), index=False
+        )
+    utils.save_merged_config(cfg, os.path.join(results_dir, "merged_config.json"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the multi-horizon backtest")
+    parser.add_argument("--config", required=True, help="Path to YAML config")
+    parser.add_argument("--results-dir", required=True, help="Where to store artefacts")
+    args = parser.parse_args()
+    cfg = utils.load_config(args.config)
+    run_backtest(cfg, args.results_dir)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backtester/execution_sim.py
+++ b/backtester/execution_sim.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+
+
+def apply_slippage(price: float, atr_val: float, cfg: Dict, side: int) -> float:
+    spread_bps = cfg.get("slippage", {}).get("min_spread_bps", 1.0)
+    atr_div = cfg.get("slippage", {}).get("atr_divisor", 1000)
+    impact = max(spread_bps / 10000 * price, atr_val / atr_div)
+    return price + side * impact
+
+
+def apply_fees(price: float, qty: float, cfg: Dict) -> float:
+    fee_bps = cfg.get("taker_fee_bps", 4)
+    return abs(price * qty) * fee_bps / 10000.0
+
+
+def simulate_fill(price: float, qty: float, side: int, atr_val: float, cfg: Dict) -> Tuple[float, float]:
+    price = apply_slippage(price, atr_val, cfg, side)
+    fee = apply_fees(price, qty, cfg)
+    return price, fee

--- a/backtester/ohlc.py
+++ b/backtester/ohlc.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+import pandas as pd
+
+
+def load_ticks(symbol: str, months: List[str], data_dir: str) -> pd.DataFrame:
+    """Load tick data for ``symbol`` from ``data_dir``.
+
+    The contract expects CSV files named ``{symbol}-ticks-{YYYY-MM}.csv`` with at
+    least the columns ``ts`` (milliseconds), ``price`` and ``qty``.
+    """
+
+    dfs = []
+    for m in months:
+        path = os.path.join(data_dir, f"{symbol}-ticks-{m}.csv")
+        if not os.path.exists(path):
+            continue
+        df = pd.read_csv(path)
+        cols = [c for c in ["ts", "price", "qty"] if c in df.columns]
+        df = df[cols]
+        df = df[(df["price"] > 0) & (df["qty"] > 0)]
+        dfs.append(df)
+    if not dfs:
+        raise FileNotFoundError(f"No tick files found for {symbol}")
+    df = pd.concat(dfs).drop_duplicates(subset="ts").sort_values("ts")
+    df = df[df["ts"].diff().fillna(1) > 0]  # enforce monotonic
+    df["timestamp"] = pd.to_datetime(df["ts"], unit="ms", utc=True)
+    df.set_index("timestamp", inplace=True)
+    return df[["price", "qty"]]
+
+
+def build_ohlcv(ticks: pd.DataFrame) -> pd.DataFrame:
+    """Create strictly causal 1m OHLCV bars from ticks."""
+
+    price = ticks["price"]
+    qty = ticks["qty"]
+    ohlc = price.resample("1T", label="right", closed="right").ohlc()
+    vol = qty.resample("1T", label="right", closed="right").sum()
+    vwap = (price * qty).resample("1T", label="right", closed="right").sum() / vol
+    bars = ohlc.join(vol.rename("volume")).join(vwap.rename("vwap"))
+    bars = bars.dropna()
+    return bars
+
+
+def resample_from_1m(bars_1m: pd.DataFrame, rule: str) -> pd.DataFrame:
+    """Resample ``bars_1m`` to a higher frequency ``rule`` using only 1m data."""
+
+    df = pd.DataFrame()
+    df["open"] = bars_1m["open"].resample(rule, label="right", closed="right").first()
+    df["high"] = bars_1m["high"].resample(rule, label="right", closed="right").max()
+    df["low"] = bars_1m["low"].resample(rule, label="right", closed="right").min()
+    df["close"] = bars_1m["close"].resample(rule, label="right", closed="right").last()
+    df["volume"] = bars_1m["volume"].resample(rule, label="right", closed="right").sum()
+    num = (bars_1m["vwap"] * bars_1m["volume"]).resample(rule, label="right", closed="right").sum()
+    df["vwap"] = num / df["volume"]
+    return df.dropna()

--- a/backtester/portfolio.py
+++ b/backtester/portfolio.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+def vol_forecast(returns: pd.Series, cfg: Dict) -> pd.Series:
+    method = cfg.get("forecast", {}).get("method", "ewma")
+    if method == "ewma":
+        alpha = cfg.get("forecast", {}).get("ewma_alpha", 0.06)
+        vol = returns.ewm(alpha=alpha, adjust=False).std().shift(1)
+    else:
+        window = cfg.get("forecast", {}).get("window", 60)
+        vol = returns.rolling(window).std().shift(1)
+    floor = cfg.get("forecast", {}).get("floor_sigma", 0.0005)
+    return vol.clip(lower=floor)
+
+
+def position_notional(price: float, sigma: float, cfg: Dict) -> float:
+    target = cfg.get("target_sigma_annual", 0.12)
+    base = cfg.get("per_symbol_notional_cap_usd", 20000)
+    ann_factor = np.sqrt(365 * 24 * 60)
+    forecast_ann = sigma * ann_factor
+    notional = target / forecast_ann * base if forecast_ann > 0 else base
+    cap = cfg.get("per_symbol_notional_cap_usd", 20000)
+    return float(np.clip(notional, -cap, cap))

--- a/backtester/risk.py
+++ b/backtester/risk.py
@@ -1,10 +1,84 @@
-# backtester/risk.py
 from __future__ import annotations
 
-def vol_target_notional(equity: float, target_annual_vol: float, vol_forecast: float, cap: float | None = None) -> float:
-    if vol_forecast <= 0:
-        return 0.0
-    notional = (target_annual_vol / vol_forecast) * equity
-    if cap is not None:
-        notional = min(notional, cap * equity)
-    return max(0.0, notional)
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class Position:
+    side: int  # 1 for long, -1 for short
+    qty: float
+    entry_price: float
+    sl: float
+    tp: float
+    be_moved: bool = False
+    tsl_active: bool = False
+
+
+def atr(bars: pd.DataFrame, period: int) -> pd.Series:
+    high = bars["high"]
+    low = bars["low"]
+    close = bars["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat([
+        (high - low),
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    return tr.rolling(period).mean().shift(1)
+
+
+def initial_sl_tp(price: float, atr_val: float, side: int, cfg: Dict) -> (float, float):
+    sl_mult = cfg.get("sl_mult", 2.0)
+    tp_mult = cfg.get("tp_mult", 3.0)
+    if side == 1:
+        sl = price - sl_mult * atr_val
+        tp = price + tp_mult * atr_val
+    else:
+        sl = price + sl_mult * atr_val
+        tp = price - tp_mult * atr_val
+    return sl, tp
+
+
+def maybe_move_be(pos: Position, current_price: float, cfg: Dict) -> None:
+    if pos.be_moved:
+        return
+    threshold = cfg.get("be_threshold", 0.55)
+    dist = abs(pos.tp - pos.entry_price)
+    if abs(current_price - pos.entry_price) >= threshold * dist:
+        pos.sl = pos.entry_price
+        pos.be_moved = True
+
+
+def maybe_trail(pos: Position, atr_val: float, current_price: float, cfg: Dict) -> None:
+    arm_th = cfg.get("tsl", {}).get("arm_threshold", 0.75)
+    atr_mult = cfg.get("tsl", {}).get("atr_mult", 1.25)
+    dist = abs(pos.tp - pos.entry_price)
+    if not pos.tsl_active and abs(current_price - pos.entry_price) >= arm_th * dist:
+        pos.tsl_active = True
+    if pos.tsl_active:
+        if pos.side == 1:
+            pos.sl = max(pos.sl, current_price - atr_mult * atr_val)
+        else:
+            pos.sl = min(pos.sl, current_price + atr_mult * atr_val)
+
+
+def check_exit(pos: Position, bar: pd.Series) -> Optional[float]:
+    """Return exit price if stop/target hit within ``bar`` else ``None``."""
+
+    high = bar["high"]
+    low = bar["low"]
+    if pos.side == 1:
+        if low <= pos.sl:
+            return pos.sl
+        if high >= pos.tp:
+            return pos.tp
+    else:
+        if high >= pos.sl:
+            return pos.sl
+        if low <= pos.tp:
+            return pos.tp
+    return None

--- a/backtester/signals.py
+++ b/backtester/signals.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+from scipy.stats import percentileofscore
+
+
+def _rolling_slope(series: pd.Series, window: int) -> pd.Series:
+    x = np.arange(window)
+    def calc(y):
+        if np.any(np.isnan(y)):
+            return np.nan
+        coef = np.polyfit(x, y, 1)
+        return coef[0]
+    return series.rolling(window).apply(calc, raw=True)
+
+
+def macro_regime(minute_index: pd.Index, bars_1h: pd.DataFrame, bars_4h: pd.DataFrame,
+                  bars_1d: pd.DataFrame, cfg: Dict) -> pd.Series:
+    """Compute macro regime using multi‑horizon TSMOM consensus."""
+
+    lookbacks = cfg.get("lookbacks", [20, 60, 120])
+    score = pd.Series(0.0, index=minute_index)
+    for tf_bars in [bars_1h, bars_4h, bars_1d]:
+        lc = np.log(tf_bars["close"])
+        for lb in lookbacks:
+            r = lc.diff(lb)
+            s = np.sign(r)
+            s = s.reindex(minute_index, method="ffill").shift(1)
+            score = score.add(s.fillna(0), fill_value=0)
+    lc_daily = np.log(bars_1d["close"])
+    slope = _rolling_slope(lc_daily, cfg.get("slope_window_days", 60))
+    slope = np.sign(slope).reindex(minute_index, method="ffill").shift(1)
+    score = score.add(slope.fillna(0), fill_value=0)
+    bull_th = cfg.get("score_bull_threshold", 0)
+    bear_th = cfg.get("score_bear_threshold", 0)
+    regime = score.copy()
+    regime[score > bull_th] = 1
+    regime[score < -bear_th] = -1
+    regime[(score <= bull_th) & (score >= -bear_th)] = 0
+    return regime
+
+
+def micro_slope(minute_index: pd.Index, bars_15m: pd.DataFrame, cfg: Dict) -> pd.Series:
+    lc = np.log(bars_15m["close"])
+    sl = _rolling_slope(lc, cfg.get("slope_window_bars", 48))
+    sl = sl.reindex(minute_index, method="ffill").shift(1)
+    return sl
+
+
+def compression(minute_bars: pd.DataFrame, cfg: Dict) -> pd.Series:
+    if not cfg.get("enabled", True):
+        return pd.Series(True, index=minute_bars.index)
+    lookback = cfg.get("lookback", 50)
+    close = minute_bars["close"]
+    ma = close.rolling(lookback).mean()
+    sd = close.rolling(lookback).std()
+    width = (2 * sd) / ma
+    def rank_pct(s):
+        if s.isna().any():
+            return np.nan
+        return percentileofscore(s[:-1], s.iloc[-1])
+    pct = width.rolling(lookback).apply(rank_pct, raw=False)
+    pct = pct.shift(1)
+    return pct <= cfg.get("percentile", 35)
+
+
+def donchian(minute_bars: pd.DataFrame, lookback: int) -> pd.DataFrame:
+    high = minute_bars["high"].rolling(lookback).max().shift(1)
+    low = minute_bars["low"].rolling(lookback).min().shift(1)
+    return pd.DataFrame({"high": high, "low": low})

--- a/backtester/utils.py
+++ b/backtester/utils.py
@@ -1,19 +1,90 @@
 # backtester/utils.py
-from __future__ import annotations
-import os, json, random
-import numpy as np
+"""Utility helpers for the event driven backtester.
 
-def seed_everything(seed: int = 42):
+This module intentionally keeps dependencies light and provides a couple of
+helpers that are reused across the new multi‑horizon backtest stack:
+
+* deterministic seeding
+* configuration loading/merging
+* filesystem helpers
+* structured logging setup
+
+The functions are deliberately small so they can be easily unit tested.  The
+logger returned by :func:`get_logger` writes to the results directory and logs
+to stdout which keeps the CLI ergonomic while still persisting artefacts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+from typing import Any, Dict
+
+import numpy as np
+import yaml
+
+
+def seed_everything(seed: int = 42) -> None:
+    """Seed Python's ``random`` and ``numpy`` RNGs."""
+
     random.seed(seed)
     np.random.seed(seed)
 
-def ensure_dir(path: str):
+
+def ensure_dir(path: str) -> None:
+    """Create ``path`` if it does not already exist."""
+
     os.makedirs(path, exist_ok=True)
 
-def save_merged_config(cfg, path: str):
+
+def load_config(path: str) -> Dict[str, Any]:
+    """Load a YAML configuration file."""
+
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``override`` into ``base`` and return the result."""
+
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = merge_dicts(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+def save_merged_config(cfg: Dict[str, Any], path: str) -> None:
+    """Persist the final resolved configuration for exact reproducibility."""
+
     with open(path, "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
 
-def write_advisory(path: str, msg: str):
+
+def get_logger(name: str, log_path: str) -> logging.Logger:
+    """Return a structured logger writing to ``log_path`` and stdout."""
+
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    fh = logging.FileHandler(log_path)
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+    sh = logging.StreamHandler()
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    return logger
+
+
+def write_advisory(path: str, msg: str) -> None:
+    """Write a short advisory message when no trades were produced."""
+
     with open(path, "w", encoding="utf-8") as f:
         f.write(msg.strip() + "\n")
+

--- a/configs/backtest.yaml
+++ b/configs/backtest.yaml
@@ -1,0 +1,81 @@
+seed: 42
+data:
+  dir: "data"
+  months: ["2025-01","2025-02","2025-03","2025-04","2025-05","2025-06","2025-07"]
+  symbols: ["BTCUSDT","ETHUSDT","SOLUSDT","BNBUSDT"]
+
+engine:
+  timezone: "UTC"
+  write_intermediate_resamples: false
+
+horizons:
+  exec: "1T"
+  micro: "15T"
+  macro: "60T"
+  daily: "1D"
+
+warmup:
+  daily_lookback_closes: 120
+  micro_lookback_bars: 48
+  macro_lookback_bars: 60
+  atr_period_exec: 20
+  donchian_exec: 20
+  bbwidth_lookback_exec: 50
+
+signals:
+  regime:
+    lookbacks: [20, 60, 120]
+    slope_window_days: 60
+    score_bull_threshold: 0
+    score_bear_threshold: 0
+  micro:
+    slope_window_bars: 48
+    min_slope_long: 0.0
+    max_slope_short: 0.0
+  trigger:
+    mode: "donchian"
+    donchian_lookback: 20
+    ksigma_k: 2.25
+  compression:
+    enabled: true
+    percentile: 35
+    lookback: 50
+
+risk:
+  atr_period: 20
+  sl_mult: 2.0
+  tp_mult: 3.0
+  be_threshold: 0.55
+  tsl:
+    arm_threshold: 0.75
+    atr_mult: 1.25
+  daily_loss_limit_pct: 5.0
+  cooldown_losses: 3
+
+sizing:
+  mode: "vol_target"
+  target_sigma_annual: 0.12
+  forecast:
+    method: "ewma"
+    ewma_alpha: 0.06
+    floor_sigma: 0.0005
+  per_symbol_notional_cap_usd: 20000
+  portfolio_gross_cap_usd: 50000
+
+costs:
+  taker_fee_bps: 4
+  maker_fee_bps: 2
+  slippage:
+    mode: "atr_fraction"
+    atr_divisor: 1000
+    min_spread_bps: 1.0
+
+limits:
+  data_stale_sec_kill: 10
+  latency_bars: 0
+
+reports:
+  write_trades: true
+  write_equity: true
+  write_bootstrap: true
+  write_logs: true


### PR DESCRIPTION
## Summary
- Add event-driven CLI `backtest_multi_horizon.py` orchestrating tick->bar processing, signal stack, risk and execution simulation
- Introduce supporting modules for OHLC resampling, signal generation, ATR-based risk, execution costs, volatility targeting, and configuration utilities
- Provide default `configs/backtest.yaml` for reproducible multi-symbol backtests

## Testing
- `python -m backtester.backtest_multi_horizon --config configs/backtest.yaml --results-dir results` *(fails: No tick files found for BTCUSDT)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a05a39a8832ba698a8d5aa49edd4