### PR TITLE
Improve loader progress bars and extend sample months

### DIFF
--- a/configs/backtest.yaml
+++ b/configs/backtest.yaml
@@ -1,8 +1,8 @@
 data:
   data_dir: ./data
-  symbols: [BTCUSDT]
-  months: ["2025-01"]
-  resample_interval: 1min
+  symbols: [BTCUSDT, ETHUSDT, SOLUSDT]
+  months: ["2024-12","2025-01","2025-02","2025-03","2025-04","2025-05","2025-06","2025-07"]
+  resample_interval: "1min"
 broker:
   initial_capital: 100000
   taker_fee_bps: 1.0


### PR DESCRIPTION
## Summary
- Fix progress bar rendering by assigning positions for file and row loops and ensure chunked streaming with the default CSV engine
- Extend example config with December–July month coverage and multiple symbols

## Testing
- `PYTHONUNBUFFERED=1 PYTHONIOENCODING="utf-8" python -u backtest_multi_horizon.py --config configs/backtest.yaml --results-dir results --debug`

------
https://chatgpt.com/codex/tasks/task_e_68a0bb59d808832bab091d711fc2d476