### PR TITLE
feat: add tick month batching and CLI precedence

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -39,11 +39,5 @@ exchange:
       min_notional: 5.0
 
 backtest:
-  # Choose the months you want to stitch together (oldest -> newest)
-  months: ["2025-01", "2025-02"]
-
-  # Template for month files; supports {symbol}, {YYYY}, {MM}
-  # For native 1-minute files:
-  data_template: "data/{symbol}/{symbol}-1m-{YYYY}-{MM}.csv"
-  # Or, if you store monthly ticks:
-  # data_template: "data/{symbol}/{symbol}-ticks-{YYYY}-{MM}.csv"
+  months: ["2025-01", "2025-02", "2025-03", "2025-04", "2025-05", "2025-06", "2025-07"]
+  data_template: "data/{symbol}/{symbol}-ticks-{YYYY}-{MM}.csv"


### PR DESCRIPTION
## Summary
- support batching of monthly tick files with automatic 1m/tick fallback
- allow single-file `--data` to override months/template
- configure default tick months and template in config

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1002304832b963500e827c92069