### PR TITLE
Add dynamic warmup and slice-based history

### DIFF
--- a/core_reuse/__init__.py
+++ b/core_reuse/__init__.py
@@ -1,0 +1,2 @@
+# Makes core_reuse a regular package for reliable imports during tests
+


### PR DESCRIPTION
## Summary
- compute warmup period dynamically from strategy lookbacks
- replace per-bar concat with slice-based history in `run`/`run_df`
- finalize any open position at end of `run`
- add `__init__` for `core_reuse` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core_reuse')*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0e28e4fd0832baaeb7c864587f79f