### PR TITLE
Use true range for ATR and increase warmup

### DIFF
--- a/core_reuse/risk.py
+++ b/core_reuse/risk.py
@@ -34,13 +34,37 @@ class RiskManager:
         self.cfg = cfg
 
     def compute_atr(self, df_hlc: pd.DataFrame, window: int, smoothing='ema', ema_halflife_bars=10) -> float:
-        if len(df_hlc) < window:
+        """
+        Robust ATR:
+        - Uses True Range (TR) with previous close
+        - Returns NaN if insufficient bars
+        - EMA smoothing via halflife; fallback to SMA if requested
+        """
+        w = max(int(window or 0), 1)
+        # Need at least w bars, but TR uses prev close, so require w+1 raw bars
+        if len(df_hlc) < (w + 1):
             return float('nan')
-        # simple EMA on TR for demo
-        tr = (df_hlc['high'] - df_hlc['low']).fillna(0.0)
-        alpha = 1.0 - np.exp(np.log(0.5) / max(1, ema_halflife_bars))
-        atr = pd.Series(_ema(tr.values[-window:], alpha))[-1]
-        return float(atr)
+
+        h = df_hlc['high'].to_numpy(dtype=float)
+        l = df_hlc['low'].to_numpy(dtype=float)
+        c = df_hlc['close'].to_numpy(dtype=float)
+
+        # previous close (first TR uses same close to avoid NaN)
+        prev_c = np.roll(c, 1)
+        prev_c[0] = c[0]
+
+        tr = np.maximum.reduce([h - l, np.abs(h - prev_c), np.abs(l - prev_c)])
+        tr_ser = pd.Series(tr, index=df_hlc.index).tail(w)
+
+        if smoothing == 'ema':
+            # alpha from halflife
+            alpha = 1.0 - np.exp(np.log(0.5) / max(1, int(ema_halflife_bars)))
+            # Use the internal EMA helper but index **positionally**
+            atr_list = _ema(tr_ser.values, alpha)
+            return float(atr_list[-1])
+        else:
+            # simple SMA ATR
+            return float(tr_ser.mean())
 
     def initial_levels(self, side: str, entry: float, atr_val: float, symcfg: dict) -> tuple:
         stops = self.cfg['risk']['stops']


### PR DESCRIPTION
## Summary
- Compute ATR using True Range with positional EMA and NaN guard
- Require an extra warmup bar and skip entries when ATR unavailable

## Testing
- `PYTHONPATH=. pytest` *(fails: No data files found for the requested range)*

------
https://chatgpt.com/codex/tasks/task_e_68a199f488d0832b8a10235efad3535a