### PR TITLE
Add progress hooks and fix timestamp floor handling

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1,8 +1,7 @@
-import argparse, os, sys
-from collections import defaultdict
+import argparse
 from tqdm import tqdm
-
 from src.engine.backtest import run_all
+
 
 def main():
     ap = argparse.ArgumentParser(description="WaveGate Momentum Backtester")
@@ -11,29 +10,26 @@ def main():
     args = ap.parse_args()
 
     bars = {}
+
     def hook(symbol, done, total):
         if args.no_progress:
             return
         key = symbol.upper()
         if key not in bars:
-            # Create a fresh tqdm per symbol
             bars[key] = tqdm(total=total, desc=f"{key} bars", position=len(bars), ncols=100, leave=True)
-        # Clamp and update delta
         done = max(0, min(done, bars[key].total))
         delta = done - bars[key].n
         if delta > 0:
             bars[key].update(delta)
 
-    # Run engine (this will also show internal per-symbol bar if enabled there)
     run_all(args.config, progress_hook=None if args.no_progress else hook)
 
-    # Close bars cleanly
     for tb in bars.values():
         try:
             tb.close()
         except Exception:
             pass
 
+
 if __name__ == "__main__":
-    # Allow module execution: python -m run_backtest
     main()


### PR DESCRIPTION
## Summary
- Ensure tick timestamps are converted to a `DatetimeIndex` before flooring to minutes, supporting ms, seconds, and ISO strings.
- Add optional `progress_hook` to `run_for_symbol` and `run_all` for external progress tracking.
- Rework `run_backtest` runner to forward progress updates and manage per-symbol tqdm bars.

## Testing
- `python -m pytest`
- `python run_backtest.py --config configs/default.yaml --no-progress` *(fails: No monthly files found for symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ac28630832b98182b48496058fd