### PR TITLE
Use minute-based resampling and tqdm progress bars

### DIFF
--- a/src/engine/regime.py
+++ b/src/engine/regime.py
@@ -17,9 +17,9 @@ class TSMOMRegime:
             if tf == "1m":
                 closes = df1m['close']
             elif tf == "5m":
-                closes = resample_ohlcv(df1m, '5T')['close']
+                closes = resample_ohlcv(df1m, '5min')['close']
             elif tf == "15m":
-                closes = resample_ohlcv(df1m, '15T')['close']
+                closes = resample_ohlcv(df1m, '15min')['close']
             elif tf == "1h":
                 closes = resample_ohlcv(df1m, '1H')['close']
             else:

--- a/src/engine/waves.py
+++ b/src/engine/waves.py
@@ -130,7 +130,7 @@ class WaveGate:
         if len(df1m) < 200:
             return {'armed': False}
 
-        df5 = resample_ohlcv(df1m, '5T')
+        df5 = resample_ohlcv(df1m, '5min')
         if len(df5) < 60:
             return {'armed': False}
 


### PR DESCRIPTION
## Summary
- replace deprecated 'T' frequency with 'min'
- show tqdm progress bar when loading monthly data
- resample using 5min/15min periods

## Testing
- `python -m py_compile src/engine/data.py src/engine/regime.py src/engine/waves.py run_backtest.py`
- `python run_backtest.py --config configs/default.yaml --no-progress` *(fails: No monthly files found for BTCUSDT ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d0fc9b8832ba54d5ae51aa95d78