### PR TITLE
Harden timestamp parsing and normalize resampling

### DIFF
--- a/src/engine/utils.py
+++ b/src/engine/utils.py
@@ -3,14 +3,10 @@ import numpy as np
 import pandas as pd
 
 def _normalize_rule(rule: str) -> str:
-    """
-    Normalize pandas offset aliases to avoid FutureWarnings:
-      'T' → 'min', 'H' → 'h'
-      Works for composites like '5T' → '5min'
-    """
+    """Normalize pandas offset aliases to avoid FutureWarnings."""
     r = str(rule)
-    r = r.replace('T', 'min')
-    r = r.replace('H', 'h')
+    r = r.replace('T', 'min')  # '5T' → '5min'
+    r = r.replace('H', 'h')    # '1H' → '1h'
     return r
 
 def ensure_datetime_utc(s):


### PR DESCRIPTION
## Summary
- Robust timestamp parser handles mixed numeric/string tick data and drops unparseable rows
- Normalized resample rules to avoid deprecation warnings
- Replaced deprecated get_loc padding with get_indexer for WaveGate and guarded index lookups

## Testing
- `python -m py_compile src/engine/data.py src/engine/utils.py src/engine/waves.py src/engine/regime.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4e0d7eca4832ba1e824cdd145ab95