### PR TITLE
Improve stop management and speed up backtests

### DIFF
--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1,71 +1,29 @@
-import argparse, warnings
-from collections import defaultdict
+import os, json, argparse, yaml, multiprocessing as mp
 from tqdm import tqdm
-from src.engine.backtest import run_all
+from src.engine.backtest import run_for_symbol as _run_symbol
 
 
-def main():
-    ap = argparse.ArgumentParser(description="WaveGate Momentum Backtester")
-    ap.add_argument("--config", required=True, help="Path to YAML config")
-    ap.add_argument("--no-progress", action="store_true", help="Disable progress bars")
-    ap.add_argument("--suppress-warnings", action="store_true", help="Hide warnings for clean bars")
-    args = ap.parse_args()
-
-    if args.suppress_warnings:
-        warnings.filterwarnings("ignore", category=FutureWarning)
-
-    bars = {}
-    overall = None
-    per_done = defaultdict(int)
-
-    def hook(symbol, done, total):
-        if args.no_progress:
-            return
-        key = symbol.upper()
-        if key not in bars:
-            bars[key] = tqdm(total=total, desc=f"{key} bars", position=len(bars), ncols=100,
-                             mininterval=0.2, smoothing=0.1, leave=True, dynamic_ncols=True)
-        # Per-symbol update
-        done = max(0, min(done, bars[key].total))
-        delta = done - bars[key].n
-        if delta > 0:
-            bars[key].update(delta)
-            per_done[key] = bars[key].n
-        # Overall bar
-        show_overall = True
-        try:
-            # prefer YAML flag if available (safe default true)
-            from yaml import safe_load
-        except Exception:
-            pass
-        if overall is None:
-            total_all = sum(b.total for b in bars.values())
-            if total_all > 0:
-                overall_desc = "ALL bars"
-                overall_position = len(bars) + 1
-                overall = tqdm(total=total_all, desc=overall_desc, position=overall_position,
-                               mininterval=0.2, smoothing=0.1, leave=True, dynamic_ncols=True)
-        if overall is not None:
-            # recompute aggregate delta robustly
-            agg_done = sum(b.n for b in bars.values())
-            delta_overall = agg_done - overall.n
-            if delta_overall > 0:
-                overall.update(delta_overall)
-
-    run_all(args.config, progress_hook=None if args.no_progress else hook)
-
-    # Close bars
-    for tb in bars.values():
-        try:
-            tb.close()
-        except Exception:
-            pass
-    if overall is not None:
-        try:
-            overall.close()
-        except Exception:
-            pass
+def run_for_symbol(args):
+    symbol, cfg = args
+    summary = _run_symbol(cfg, symbol)
+    return symbol, summary
 
 
 if __name__ == "__main__":
-    main()
+    ap = argparse.ArgumentParser(description="WaveGate Momentum Backtester")
+    ap.add_argument("--config", required=True, help="Path to YAML config")
+    args = ap.parse_args()
+
+    with open(args.config, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    symbols = cfg['symbols']
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=min(len(symbols), os.cpu_count())) as pool:
+        results = list(tqdm(pool.imap_unordered(run_for_symbol, [(s, cfg) for s in symbols]),
+                            total=len(symbols), desc="Symbols"))
+    combined = {sym: summ for sym, summ in results}
+    os.makedirs(cfg['paths']['outputs_dir'], exist_ok=True)
+    with open(os.path.join(cfg['paths']['outputs_dir'], "combined_summary.json"), "w") as f:
+        json.dump(combined, f, indent=2)
+    print("Done.")

--- a/src/engine/risk.py
+++ b/src/engine/risk.py
@@ -4,6 +4,15 @@ import pandas as pd
 from .utils import atr
 
 EXIT_SL, EXIT_TP, EXIT_BE, EXIT_TSL = "SL","TP","BE","TSL"
+EPS = 1e-9
+
+
+def _locked_r(trade, stop_price: float) -> float:
+    r0 = max(EPS, float(trade['r0']))
+    if trade['direction'] == 'LONG':
+        return (float(stop_price) - float(trade['entry'])) / r0
+    else:
+        return (float(trade['entry']) - float(stop_price)) / r0
 
 @dataclass
 class RiskCfg:
@@ -25,42 +34,98 @@ def initial_stop(entry_price: float, direction: str, wave_state: dict, df1m: pd.
         atr_stop = entry_price + cfg.sl_atr_mult * a
         return min(struct, atr_stop)
 
-def update_stops(trade: dict, row, atr_last, cfg: RiskCfg):
+def update_stops(trade: dict, row, atr_last: float, cfg: dict):
     """
-    trade: dict with entry, stop, direction, r0 (initial risk distance)
-    row: last 1m row
+    BE = exactly entry (no buffer). TSL respects BE floor and never widens.
+    Required cfg keys:
+      - be_trigger_r = cfg['risk']['be']['trigger_r_multiple']
+      - tsl_start_r  = cfg['risk']['tsl']['start_r_multiple']
+      - tsl_atr_mult = cfg['risk']['tsl']['atr_mult']
     """
     if trade.get('exit'):
         return
-    price = row['close']
-    if trade['direction'] == 'LONG':
-        up = price - trade['entry']
-        r = up / max(1e-9, trade['r0'])
-        # BE
-        if (not trade.get('be_armed', False)) and r >= cfg.be_trigger_r:
-            trade['stop'] = max(trade['stop'], trade['entry'])
-            trade['be_armed'] = True
-        # TSL
-        if r >= cfg.tsl_start_r:
-            trailing = price - cfg.tsl_atr_mult * atr_last
-            trade['stop'] = max(trade['stop'], trailing)
-    else:
-        down = trade['entry'] - price
-        r = down / max(1e-9, trade['r0'])
-        if (not trade.get('be_armed', False)) and r >= cfg.be_trigger_r:
-            trade['stop'] = min(trade['stop'], trade['entry'])
-            trade['be_armed'] = True
-        if r >= cfg.tsl_start_r:
-            trailing = price + cfg.tsl_atr_mult * atr_last
-            trade['stop'] = min(trade['stop'], trailing)
+
+    price = float(row['close'])
+    entry = float(trade['entry'])
+    r0 = max(EPS, float(trade['r0']))
+    long = (trade['direction'] == 'LONG')
+
+    # unrealized R now, update r_peak
+    r_now = (price - entry)/r0 if long else (entry - price)/r0
+    trade['r_peak'] = max(float(trade.get('r_peak', 0.0)), float(r_now))
+
+    be_trigger_r = float(cfg['risk']['be']['trigger_r_multiple'])
+    tsl_start_r  = float(cfg['risk']['tsl']['start_r_multiple'])
+    tsl_atr_mult = float(cfg['risk']['tsl']['atr_mult'])
+
+    # 1) Arm BE (no buffer) → stop = entry
+    if not trade.get('be_armed', False) and r_now >= be_trigger_r:
+        if long:
+            trade['stop'] = max(float(trade['stop']), entry)
+        else:
+            trade['stop'] = min(float(trade['stop']), entry)
+        trade['be_floor'] = entry  # used as floor/ceiling for TSL classification
+        trade['be_armed'] = True
+
+    be_floor = float(trade.get('be_floor', entry))
+
+    # 2) Trailing stop after tsl_start_r; respect BE floor; never widen
+    if r_now >= tsl_start_r:
+        trade['tsl_active'] = True
+        if long:
+            candidate = price - tsl_atr_mult * float(atr_last)
+            # if BE armed, TSL must be strictly past entry
+            if trade.get('be_armed', False):
+                candidate = max(candidate, be_floor + EPS)
+            trade['stop'] = max(float(trade['stop']), candidate)  # monotonic
+        else:
+            candidate = price + tsl_atr_mult * float(atr_last)
+            if trade.get('be_armed', False):
+                candidate = min(candidate, be_floor - EPS)
+            trade['stop'] = min(float(trade['stop']), candidate)
+
+        # Track max locked R by the trailer
+        trade['tsl_lock_R_max'] = max(
+            float(trade.get('tsl_lock_R_max', 0.0)),
+            float(_locked_r(trade, float(trade['stop'])))
+        )
+
 
 def check_exit(trade: dict, row):
+    """
+    Stop-touch classification with precedence:
+      - if BE armed and stop <= entry (+EPS long / -EPS short) → BE
+      - elif TSL active and stop beyond entry → TSL
+      - else → SL
+    """
     if trade.get('exit'):
         return
-    if trade['direction'] == 'LONG':
-        if row['low'] <= trade['stop']:
-            trade['exit'] = trade['stop']; trade['exit_reason'] = EXIT_SL if not trade.get('be_armed') else EXIT_TSL
-        # TP optional (not used by default)
+
+    entry = float(trade['entry'])
+    be_floor = float(trade.get('be_floor', entry))
+    long = (trade['direction'] == 'LONG')
+
+    if long:
+        if float(row['low']) <= float(trade['stop']):
+            trade['exit'] = float(trade['stop'])
+            if trade.get('be_armed', False):
+                if trade['stop'] <= be_floor + EPS:
+                    trade['exit_reason'] = EXIT_BE
+                elif trade.get('tsl_active', False) and trade['stop'] > be_floor + EPS:
+                    trade['exit_reason'] = EXIT_TSL
+                else:
+                    trade['exit_reason'] = EXIT_BE
+            else:
+                trade['exit_reason'] = EXIT_SL
     else:
-        if row['high'] >= trade['stop']:
-            trade['exit'] = trade['stop']; trade['exit_reason'] = EXIT_SL if not trade.get('be_armed') else EXIT_TSL
+        if float(row['high']) >= float(trade['stop']):
+            trade['exit'] = float(trade['stop'])
+            if trade.get('be_armed', False):
+                if trade['stop'] >= be_floor - EPS:
+                    trade['exit_reason'] = EXIT_BE
+                elif trade.get('tsl_active', False) and trade['stop'] < be_floor - EPS:
+                    trade['exit_reason'] = EXIT_TSL
+                else:
+                    trade['exit_reason'] = EXIT_BE
+            else:
+                trade['exit_reason'] = EXIT_SL


### PR DESCRIPTION
## Summary
- Overhauled break-even and trailing stop logic with explicit exit classification and diagnostic tracking
- Emitted per-symbol trade summaries with BE/TSL metrics and concise console output
- Parallelized backtests across symbols and optimized tick loading/resampling for faster runs

## Testing
- `python -m py_compile run_backtest.py src/engine/backtest.py src/engine/risk.py src/engine/data.py`
- `python run_backtest.py --config configs/default.yaml` *(fails: No monthly files found for BTCUSDT)*


------
https://chatgpt.com/codex/tasks/task_e_68a7f25d2a98832b97ca068f4d383b7a