### PR TITLE
Implement multi-timeframe TSMOM regime with per-TF lookbacks and majority vote

### DIFF
--- a/src/engine/regime.py
+++ b/src/engine/regime.py
@@ -1,75 +1,177 @@
+"""Time-series momentum regime engine.
+
+This module implements a causal, multi–time-frame regime detector based on
+simple time-series momentum (TSMOM).  The detector works off of 1 minute OHLCV
+data and for each configured timeframe calculates the directional bias by
+examining the sign of the difference between the most recent close and prior
+closes.  A majority vote across timeframes produces the overall regime.
+
+The configuration expected by :class:`TSMOMRegime` matches the block below::
+
+    regime:
+      timeframes:
+        "1m":  { lookback_closes: 30 }
+        "5m":  { lookback_closes: 20 }
+        "15m": { lookback_closes: 12 }
+        "1h":  { lookback_closes: 8 }
+        "5h":  { lookback_closes: 3 }
+      vote:
+        require: 4
+
+For each timeframe we resample the 1m data to the target bar size using a
+right‑closed, label='right' rule so that the bar ending at ``ts`` only contains
+data up to and including ``ts``.  The direction for a timeframe is determined
+by summing the signs of ``close_t - close_{t-k}`` for ``k = 1 .. N`` where ``N``
+is the ``lookback_closes``.  The score for a timeframe is the average of these
+signs and acts as a conviction metric.  Optionally a ``strength`` metric is
+computed from the average absolute z-score of the percentage returns used in
+the sign calculation.
+
+The overall regime direction is decided by a majority vote.  If the number of
+bullish timeframes exceeds or equals ``require`` and strictly exceeds the
+number of bearish timeframes the regime is ``BULL``; the converse gives ``BEAR``
+and otherwise the regime is ``FLAT``.  The overall score is the mean of the
+timeframe scores and the strength is the median of the per-timeframe strengths.
+"""
+
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 
-TF_MAP = {
-    "1min": "1min",
-    "5min": "5min",
-    "15min": "15min",
+TF_RULE = {
+    "1m": "1min",
+    "5m": "5min",
+    "15m": "15min",
     "1h": "1H",
     "5h": "5H",
 }
 
-BULL, BEAR, FLAT = "BULL", "BEAR", "FLAT"
 
-
-def _resample(df1m, tf):
-    if tf == "1min":
+def _resample_ohlcv(df1m: pd.DataFrame, tf_key: str) -> pd.DataFrame:
+    """Resample 1m OHLCV to target timeframe, label/right-closed, causal."""
+    rule = TF_RULE[tf_key]
+    if rule == "1min":  # passthrough for 1m
         return df1m
-    rule = TF_MAP[tf]
-    return df1m.resample(rule, label='right', closed='right').agg({
-        'open': 'first',
-        'high': 'max',
-        'low': 'min',
-        'close': 'last',
-        'volume': 'sum'
-    }).dropna()
+    return (
+        df1m.resample(rule, label="right", closed="right")
+        .agg(
+            {
+                "open": "first",
+                "high": "max",
+                "low": "min",
+                "close": "last",
+                "volume": "sum",
+            }
+        )
+        .dropna()
+    )
 
 
 class TSMOMRegime:
+    """Multi-TF TSMOM regime with per-timeframe lookback and majority vote."""
+
     def __init__(self, cfg: dict, df1m: pd.DataFrame):
         self.cfg = cfg
-        self.tf_specs = cfg['regime']['ts_mom']['timeframes']
-        self.require = int(cfg['regime']['ts_mom']['require_majority'])
-        self.frames = {spec['tf']: _resample(df1m, spec['tf']) for spec in self.tf_specs}
+        # Mapping timeframe -> {lookback_closes: int}
+        self.specs = cfg["regime"]["timeframes"]
+        self.require = int(cfg["regime"]["vote"]["require"])
 
-    def compute_at(self, ts) -> dict:
+        # Pre-resample once for efficiency.  The returned frames are causal and
+        # we slice them using ``get_indexer`` when computing the regime.
+        self.frames = {tf: _resample_ohlcv(df1m, tf) for tf in self.specs.keys()}
+
+    # ------------------------------------------------------------------
+    def _tf_direction_and_score(
+        self, df_tf: pd.DataFrame, ts: pd.Timestamp, n_closes: int
+    ) -> tuple[int, float, float] | None:
+        """Return ``(dir_int, score, strength)`` for a single timeframe.
+
+        ``dir_int`` is ``-1`` for bearish, ``0`` for tie and ``+1`` for bullish.
+        ``score`` is the average of the individual signs (conviction in
+        ``[-1, +1]``) and ``strength`` is the mean absolute z-score of the
+        percentage returns used for the signs.  ``None`` is returned if there is
+        insufficient history (warm-up guard).
+        """
+
+        # Guard: timestamp earlier than first bar
+        if ts < df_tf.index[0]:
+            return None
+
+        # Get index position of the bar at or immediately preceding ``ts``
+        j = df_tf.index.get_indexer([ts], method="pad")[0]
+        if j == -1 or j < n_closes:
+            # Not enough data yet (need N+1 bars including current)
+            return None
+
+        close = df_tf["close"].iloc[: j + 1]
+
+        signs = []
+        pct = []
+        last = close.iloc[-1]
+        for k in range(1, n_closes + 1):
+            prev = close.iloc[-1 - k]
+            signs.append(np.sign(last - prev))
+            pct.append((last / prev) - 1.0)
+
+        signs = np.array(signs, dtype=float)
+        dir_int = int(np.sign(signs.sum()))
+        tf_score = float(signs.mean())
+
+        # Strength: mean absolute z-score of the percentage returns
+        x = np.array(pct, dtype=float)
+        if np.isfinite(x).all() and x.std() > 0:
+            z = (x - x.mean()) / (x.std() + 1e-12)
+            tf_strength = float(np.abs(z).mean())
+        else:
+            tf_strength = 0.0
+
+        return dir_int, tf_score, tf_strength
+
+    # ------------------------------------------------------------------
+    def compute_at(self, ts: pd.Timestamp) -> dict:
+        """Compute regime at timestamp ``ts``.
+
+        Returns a dictionary with ``dir`` (``BULL``, ``BEAR`` or ``FLAT``),
+        ``score`` and ``strength``.
+        """
+
         votes = []
-        strength_parts = []
+        tf_scores = []
+        tf_strengths = []
 
-        for spec in self.tf_specs:
-            tf = spec['tf']
-            k = int(spec.get('lookback_closes', 3))
-            df = self.frames[tf]
-            if ts < df.index[0]:
-                return {'dir': FLAT, 'score': 0.0, 'strength': 0.0}
-            idx = df.index.get_indexer([ts], method='pad')[0]
-            if idx == -1:
-                return {'dir': FLAT, 'score': 0.0, 'strength': 0.0}
-            df_cut = df.iloc[:idx+1]
-            if len(df_cut) < (k+1):
-                return {'dir': FLAT, 'score': 0.0, 'strength': 0.0}
+        # Strict warm-up: if any TF doesn't have enough data -> FLAT
+        for tf, spec in self.specs.items():
+            n = int(spec.get("lookback_closes", 3))
+            frame = self.frames[tf]
+            res = self._tf_direction_and_score(frame, ts, n)
+            if res is None:
+                return {"dir": "FLAT", "score": 0.0, "strength": 0.0}
 
-            close = df_cut['close']
-            rets = [np.sign(close.iloc[-1] - close.shift(i).iloc[-1]) for i in range(1, k+1)]
-            s = int(np.sign(sum(rets)))
-            votes.append(s)
-
-            pct = [(close.iloc[-1] / close.shift(i).iloc[-1] - 1.0) for i in range(1, k+1)]
-            if np.all(np.isfinite(pct)):
-                x = np.array(pct, dtype=float)
-                if x.std() > 0:
-                    z = (x - x.mean()) / (x.std() + 1e-12)
-                    strength_parts.append(np.abs(z).mean())
+            dir_int, tf_score, tf_strength = res
+            votes.append(dir_int)
+            tf_scores.append(tf_score)
+            tf_strengths.append(tf_strength)
 
         bulls = sum(1 for v in votes if v > 0)
         bears = sum(1 for v in votes if v < 0)
-        score = (bulls - bears) / max(1, len(self.tf_specs))
 
-        dir_ = FLAT
-        if bulls >= self.require:
-            dir_ = BULL
-        elif bears >= self.require:
-            dir_ = BEAR
+        if bulls >= self.require and bulls > bears:
+            direction = "BULL"
+        elif bears >= self.require and bears > bulls:
+            direction = "BEAR"
+        else:
+            direction = "FLAT"
 
-        strength = float(np.median(strength_parts)) if strength_parts else 0.0
-        return {'dir': dir_, 'score': float(score), 'strength': strength}
+        regime_score = float(np.mean(tf_scores)) if tf_scores else 0.0
+        regime_strength = float(np.median(tf_strengths)) if tf_strengths else 0.0
+
+        return {
+            "dir": direction,
+            "score": regime_score,
+            "strength": regime_strength,
+        }
+
+
+__all__ = ["TSMOMRegime"]
+


### PR DESCRIPTION
## Summary
- implement causal multi-timeframe TSMOM regime supporting per-timeframe lookback_closes and majority vote
- integrate regime direction, score and strength into backtest trades and summaries
- update backtest to track per-bar regime statistics

## Testing
- `python -m py_compile src/engine/backtest.py src/engine/regime.py`
- `python - <<'PY'
import pandas as pd
from src.engine.regime import TSMOMRegime
idx = pd.date_range('2024-01-01', periods=1000, freq='1min')
prices = pd.Series(range(1000), index=idx)
vol = pd.Series(1, index=idx)
df = pd.DataFrame({'open':prices,'high':prices,'low':prices,'close':prices,'volume':vol})
cfg={'regime':{'timeframes':{'1m':{'lookback_closes':5},'5m':{'lookback_closes':3}},'vote':{'require':2}}}
reg=TSMOMRegime(cfg,df)
print(reg.compute_at(idx[500]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a863fcb4b4832b897f6e7758d6f8e3