### PR TITLE
Optimize backtest with caching and precomputations

### DIFF
--- a/src/engine/backtest.py
+++ b/src/engine/backtest.py
@@ -57,6 +57,9 @@ def run_for_symbol(cfg: dict, symbol: str, progress_hook=None):
     stride = int(cfg['logging'].get('progress_stride', 200))
     total_bars = len(df1m) - start_i
 
+    iloc = df1m.iloc
+    idx = df1m.index
+
     blockers = {'regime_flat': 0, 'wave_not_armed': 0, 'trigger_fail': 0}
 
     for i in range(start_i, len(df1m)):
@@ -65,11 +68,12 @@ def run_for_symbol(cfg: dict, symbol: str, progress_hook=None):
                 progress_hook(symbol, i - start_i + 1, total_bars)
             except Exception:
                 pass
-        ts = df1m.index[i]
+        ts = idx[i]
 
+        row = iloc[i]
         if trade is not None and not trade.get('exit'):
-            risk.update_trade(trade, df1m.iloc[i], i)
-            risk.check_exit(trade, df1m.iloc[i])
+            risk.update_trade(trade, row, i)
+            risk.check_exit(trade, row)
             if trade.get('exit'):
                 r0 = trade['r0']
                 if trade['direction'] == 'LONG':
@@ -105,7 +109,7 @@ def run_for_symbol(cfg: dict, symbol: str, progress_hook=None):
             continue
 
         direction = 'LONG' if reg['dir'] == 'BULL' else 'SHORT'
-        entry = df1m['close'].iloc[i]
+        entry = row['close']
         stop0 = risk.initial_stop(entry, direction, wv, i)
         r0 = entry - stop0 if direction == 'LONG' else stop0 - entry
         r0 = max(1e-9, r0)
@@ -133,7 +137,7 @@ def run_for_symbol(cfg: dict, symbol: str, progress_hook=None):
         }
 
     if trade is not None and not trade.get('exit'):
-        last = df1m.iloc[-1]
+        last = iloc[-1]
         trade['exit'] = float(last['close'])
         trade['exit_reason'] = 'EOD'
         if trade['direction'] == 'LONG':

--- a/src/engine/regime.py
+++ b/src/engine/regime.py
@@ -5,63 +5,78 @@ TF_MAP = {
     "1min": "1min",
     "5min": "5min",
     "15min": "15min",
-    "1h":   "1h",   # NOTE: lower-case 'h' to avoid deprecation
+    "1h":   "1h",
     "5h":   "5h",
 }
+
 
 def _resample(df1m, tf):
     if tf == "1min":
         return df1m
     rule = TF_MAP[tf].lower()
     return df1m.resample(rule, label='right', closed='right').agg({
-        'open':'first','high':'max','low':'min','close':'last','volume':'sum'
+        'open': 'first', 'high': 'max', 'low': 'min', 'close': 'last', 'volume': 'sum'
     }).dropna()
+
 
 class TSMOMRegime:
     def __init__(self, cfg: dict, df1m: pd.DataFrame):
         self.cfg = cfg
         self.tf_specs = cfg['regime']['ts_mom']['timeframes']
         self.require = int(cfg['regime']['ts_mom']['require_majority'])
-        # pre-resample each TF once
+
+        # pre-resample once
         self.frames = {spec['tf']: _resample(df1m, spec['tf']) for spec in self.tf_specs}
+
+        # precompute per-TF majority sign and strength arrays
+        self._prep = {}
+        for spec in self.tf_specs:
+            tf = spec['tf']
+            k = int(spec.get('lookback_closes', 3))
+            df = self.frames[tf]
+            close = df['close']
+
+            # matrix of last k percentage changes vs last close (vectorized)
+            cols = [(close / close.shift(i) - 1.0) for i in range(1, k + 1)]
+            pct = pd.concat(cols, axis=1)
+
+            signs = np.sign(pct.values)                # shape (n, k)
+            maj = np.sign(signs.sum(axis=1)).astype(int)
+            maj_series = pd.Series(maj, index=df.index)
+
+            # per-row z of those k pct changes; strength = mean |z|
+            row_mu = pct.mean(axis=1)
+            row_sd = pct.std(axis=1).replace(0, np.nan)
+            z = (pct.sub(row_mu, axis=0)).div(row_sd, axis=0)
+            strength = z.abs().mean(axis=1).fillna(0.0)
+
+            self._prep[tf] = {'maj': maj_series, 'str': strength}
 
     def compute_at(self, ts) -> dict:
         votes = []
         strength_parts = []
 
         for spec in self.tf_specs:
-            tf = spec['tf']; k = int(spec.get('lookback_closes', 3))
+            tf = spec['tf']
             df = self.frames[tf]
             if ts < df.index[0]:
-                return {'dir':'FLAT','score':0.0,'strength':0.0}
+                return {'dir': 'FLAT', 'score': 0.0, 'strength': 0.0}
             idx = df.index.get_indexer([ts], method='pad')[0]
             if idx == -1:
-                return {'dir':'FLAT','score':0.0,'strength':0.0}
+                return {'dir': 'FLAT', 'score': 0.0, 'strength': 0.0}
 
-            df_cut = df.iloc[:idx+1]
-            if len(df_cut) < (k+1):
-                return {'dir':'FLAT','score':0.0,'strength':0.0}
-
-            close = df_cut['close']
-            # signs of last k close-vs-close changes
-            rets = [np.sign(close.iloc[-1] - close.shift(i).iloc[-1]) for i in range(1, k+1)]
-            v = int(np.sign(sum(rets)))  # majority within TF; ties -> 0
-            votes.append(v)
-
-            # strength: mean |z| across those k closes
-            pct = [ (close.iloc[-1] / close.shift(i).iloc[-1] - 1.0) for i in range(1, k+1) ]
-            x = np.array(pct, dtype=float)
-            if np.all(np.isfinite(x)) and x.std() > 0:
-                z = (x - x.mean()) / (x.std() + 1e-12)
-                strength_parts.append(np.abs(z).mean())
+            votes.append(int(self._prep[tf]['maj'].iat[idx]))
+            strength_parts.append(float(self._prep[tf]['str'].iat[idx]))
 
         bulls = sum(1 for v in votes if v > 0)
         bears = sum(1 for v in votes if v < 0)
         score = (bulls - bears) / max(1, len(self.tf_specs))
 
         dir_ = 'FLAT'
-        if bulls >= self.require: dir_ = 'BULL'
-        elif bears >= self.require: dir_ = 'BEAR'
+        if bulls >= self.require:
+            dir_ = 'BULL'
+        elif bears >= self.require:
+            dir_ = 'BEAR'
 
         strength = float(np.median(strength_parts)) if strength_parts else 0.0
         return {'dir': dir_, 'score': float(score), 'strength': strength}

--- a/src/engine/trigger.py
+++ b/src/engine/trigger.py
@@ -1,15 +1,30 @@
 import pandas as pd
+import numpy as np
 
 from .adaptive import AdaptiveController
-from .utils import zscore_logret, body_dom, true_range_last
+from .utils import zscore_logret, body_dom
 
 
 class Trigger:
     def __init__(self, cfg: dict, df1m: pd.DataFrame, atr1m: pd.Series, ac: AdaptiveController):
         self.cfg = cfg
         self.df1m = df1m
-        self.atr1m = atr1m
+        self.atr1m = atr1m.replace(0, 1e-9)
         self.ac = ac
+
+        win = int(cfg['entry']['momentum']['zscore_window'])
+
+        # Precompute z-score of 1m log-returns once
+        self._zret = zscore_logret(df1m['close'], win)
+
+        # Precompute True Range / ATR once
+        prev_c = df1m['close'].shift(1)
+        tr_series = pd.concat([
+            (df1m['high'] - df1m['low']),
+            (df1m['high'] - prev_c).abs(),
+            (df1m['low']  - prev_c).abs()
+        ], axis=1).max(axis=1)
+        self._tr_over_atr = tr_series / self.atr1m
 
     def power_bar_ok(self, ts: pd.Timestamp, i_bar_1m: int) -> dict:
         tp = self.ac.trigger_params(i_bar_1m)
@@ -22,22 +37,18 @@ class Trigger:
         if i_bar_1m < win + 2:
             return {'ok': False, 'z_k': z_k, 'range_atr_min': rng_min}
 
-        df_cut = self.df1m.iloc[:i_bar_1m + 1]
-        zret = zscore_logret(df_cut['close'], win).iloc[-1]
-        last = df_cut.iloc[-1]
-        prev_close = df_cut['close'].iloc[-2]
-        body = body_dom(last)
-        tr = true_range_last(last, prev_close)
-        atr = self.atr1m.iloc[i_bar_1m]
-        tratr = tr / max(1e-9, atr)
+        last = self.df1m.iloc[i_bar_1m]
+        body = float(body_dom(last))
+        zret = float(self._zret.iat[i_bar_1m])
+        tratr = float(self._tr_over_atr.iat[i_bar_1m])
 
         ok = (abs(zret) >= z_k) and (body >= min_body) and (tratr >= rng_min)
         return {
             'ok': bool(ok),
             'z_k': z_k,
             'range_atr_min': rng_min,
-            'zret': float(zret),
-            'body_dom': float(body),
-            'tr_atr': float(tratr),
+            'zret': zret,
+            'body_dom': body,
+            'tr_atr': tratr,
         }
 


### PR DESCRIPTION
## Summary
- Add 1m OHLCV cache with Parquet/pickle fallback and typed CSV fast path
- Precompute trigger z-scores, regime votes, and wave ATR using cumsum
- Streamline progress hooks and adaptive normalization for faster backtests

## Testing
- `python -m py_compile run_backtest.py src/engine/data.py src/engine/trigger.py src/engine/regime.py src/engine/waves.py src/engine/adaptive.py src/engine/backtest.py`
- `python -m run_backtest --config configs/default.yaml --workers 1` *(fails: No monthly files found for BTCUSDT)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8025300832bb5fa4aa12ddd26bb