### PR TITLE
Add OOS and walk-forward evaluation

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -106,3 +106,11 @@ risk:
 #
 # Example commands:
 #   python -m run_backtest --config configs/default_max.yaml --workers 1
+
+backtest:
+  mode: "insample"
+  oos_last_k_months: 2
+  walkforward:
+    train_months: 3
+    test_months: 1
+    step_months: 1

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -6,9 +6,11 @@ import multiprocessing as mp
 import queue as pyqueue
 import threading
 import time
+from copy import deepcopy
 from typing import Any, Dict, List
 import yaml
 from tqdm import tqdm
+import json
 
 # ------ Progress message structure ------
 # {'type': 'init', 'symbol': str, 'total': int}
@@ -132,6 +134,8 @@ def main():
     ap = argparse.ArgumentParser(description="WaveGate Momentum Backtester")
     ap.add_argument("--config", required=True, help="Path to YAML config")
     ap.add_argument("--workers", type=int, default=0, help="Number of processes (0 = all cores)")
+    ap.add_argument("--oos_last_k_months", type=int, default=None, help="Hold-out last K months as OOS")
+    ap.add_argument("--walkforward", type=str, default=None, help="Walk-forward params 'train=3,test=1,step=1'")
     args = ap.parse_args()
 
     with open(args.config, "r") as f:
@@ -142,34 +146,128 @@ def main():
         print("No symbols specified in config")
         return
 
-    max_workers = os.cpu_count() or 1
-    workers = max_workers if args.workers in (None, 0) else max(1, args.workers)
+    bt_cfg = cfg.get('backtest', {}) or {}
+    mode = 'insample'
+    oos_k = None
+    wf_params = None
 
-    # Windows-safe spawn context + Manager Queue
-    mp_ctx = mp.get_context("spawn")
-    manager = mp_ctx.Manager()
-    q = manager.Queue(maxsize=10000)
+    if args.oos_last_k_months is not None and args.walkforward:
+        print("Cannot specify both OOS and walk-forward modes")
+        return
+    if args.oos_last_k_months is not None:
+        mode = 'oos'
+        oos_k = int(args.oos_last_k_months)
+    elif args.walkforward:
+        mode = 'walkforward'
+        wf_params = {}
+        for part in args.walkforward.split(','):
+            if '=' in part:
+                k, v = part.split('=')
+                wf_params[k.strip()] = int(v)
+    else:
+        mode = bt_cfg.get('mode', 'insample')
+        if mode == 'oos':
+            oos_k = int(bt_cfg.get('oos_last_k_months', 0))
+        elif mode == 'walkforward':
+            wf = bt_cfg.get('walkforward', {}) or {}
+            wf_params = {
+                'train': int(wf.get('train_months', 0)),
+                'test': int(wf.get('test_months', 0)),
+                'step': int(wf.get('step_months', 0)),
+            }
 
-    stop_evt = threading.Event()
-    listener_thread = threading.Thread(target=_progress_listener, args=(q, stop_evt), daemon=True)
-    listener_thread.start()
+    if mode == 'insample':
+        max_workers = os.cpu_count() or 1
+        workers = max_workers if args.workers in (None, 0) else max(1, args.workers)
 
-    summaries = []
-    try:
-        # NOTE: pass mp_context for Windows Python 3.8+ compatibility
-        with concurrent.futures.ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as ex:
-            futs = [ex.submit(_worker, (cfg, sym, q)) for sym in symbols]
-            for fut in concurrent.futures.as_completed(futs):
-                try:
-                    summaries.append(fut.result())
-                except Exception as e:
-                    summaries.append({'symbol': 'UNKNOWN', 'error': str(e)})
-    finally:
-        stop_evt.set()
-        listener_thread.join(timeout=1.0)
+        # Windows-safe spawn context + Manager Queue
+        mp_ctx = mp.get_context("spawn")
+        manager = mp_ctx.Manager()
+        q = manager.Queue(maxsize=10000)
 
-    for s in summaries:
-        print(s)
+        stop_evt = threading.Event()
+        listener_thread = threading.Thread(target=_progress_listener, args=(q, stop_evt), daemon=True)
+        listener_thread.start()
+
+        summaries = []
+        try:
+            # NOTE: pass mp_context for Windows Python 3.8+ compatibility
+            with concurrent.futures.ProcessPoolExecutor(max_workers=workers, mp_context=mp_ctx) as ex:
+                futs = [ex.submit(_worker, (cfg, sym, q)) for sym in symbols]
+                for fut in concurrent.futures.as_completed(futs):
+                    try:
+                        summaries.append(fut.result())
+                    except Exception as e:
+                        summaries.append({'symbol': 'UNKNOWN', 'error': str(e)})
+        finally:
+            stop_evt.set()
+            listener_thread.join(timeout=1.0)
+
+        for s in summaries:
+            print(s)
+    elif mode == 'oos':
+        from src.engine.data import load_symbol_1m
+        from src.engine.walkforward import df_for_months
+        from src.engine.backtest import run_for_symbol
+
+        base_out = os.path.join(cfg['paths']['outputs_dir'], 'oos')
+        os.makedirs(base_out, exist_ok=True)
+        summaries = []
+        agg_keys = [
+            'sum_r_sl', 'sum_r_be', 'sum_r_tsl', 'sum_r_sl_overshoot', 'sum_r_realized',
+            'SL_count', 'BE_count', 'TSL_count', 'trades'
+        ]
+        aggregate = {k: 0.0 for k in agg_keys}
+        aggregate['SL_count'] = 0
+        aggregate['BE_count'] = 0
+        aggregate['TSL_count'] = 0
+        aggregate['trades'] = 0
+        win_acc = 0.0
+        avg_acc = 0.0
+
+        for sym in symbols:
+            df_all = load_symbol_1m(cfg['paths']['inputs_dir'], sym, cfg['months'], progress=cfg['logging']['progress'])
+            train_months = cfg['months'][:-oos_k] if oos_k else cfg['months']
+            test_months = cfg['months'][-oos_k:] if oos_k else []
+            df_train = df_for_months(df_all, train_months)
+            df_test = df_for_months(df_all, test_months)
+            if df_test.empty:
+                continue
+            df_fold = pd.concat([df_train, df_test]).sort_index()
+            start_ts = df_test.index[0]
+            cfg_sym = deepcopy(cfg)
+            cfg_sym['paths']['outputs_dir'] = base_out
+            s = run_for_symbol(cfg_sym, sym, progress_hook=None, df1m_override=df_fold, trade_start_ts=start_ts)
+            s.update({
+                'train_months': train_months,
+                'test_months': test_months,
+                'trade_start_ts': start_ts.isoformat(),
+                'bars_train': int(len(df_train)),
+                'bars_test': int(len(df_test)),
+            })
+            summaries.append(s)
+            for k in agg_keys:
+                if k in s:
+                    aggregate[k] += s.get(k, 0.0)
+            win_acc += s.get('win_rate', 0.0) * s.get('trades', 0)
+            avg_acc += s.get('avg_R', 0.0) * s.get('trades', 0)
+        tot = aggregate.get('trades', 0)
+        if tot > 0:
+            aggregate['win_rate'] = win_acc / tot
+            aggregate['avg_R'] = avg_acc / tot
+        else:
+            aggregate['win_rate'] = 0.0
+            aggregate['avg_R'] = 0.0
+        with open(os.path.join(base_out, 'combined_summary.json'), 'w') as f:
+            json.dump({'summaries': summaries, 'aggregate': aggregate}, f, indent=2)
+        for s in summaries:
+            print(s)
+    elif mode == 'walkforward':
+        from src.engine.walkforward import run_walkforward
+
+        params = wf_params or {'train': 0, 'test': 0, 'step': 0}
+        for sym in symbols:
+            run_walkforward(cfg, sym, params.get('train', 0), params.get('test', 0), params.get('step', 0))
 
 
 if __name__ == "__main__":

--- a/src/engine/walkforward.py
+++ b/src/engine/walkforward.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import json
+from copy import deepcopy
+from typing import List, Dict
+
+import pandas as pd
+
+from .data import load_symbol_1m
+from .backtest import run_for_symbol
+
+
+def split_months(months: List[str], train: int, test: int, step: int) -> List[Dict[str, List[str]]]:
+    folds = []
+    n = len(months)
+    i = 0
+    while i + train < n:
+        m_train = months[i : i + train]
+        m_test = months[i + train : i + train + test]
+        if not m_test:
+            break
+        folds.append({'train': m_train, 'test': m_test})
+        i += step
+    return folds
+
+
+def df_for_months(df_all: pd.DataFrame, months: List[str]) -> pd.DataFrame:
+    if not months:
+        return df_all.iloc[0:0].copy()
+    months_set = set(months)
+    mask = df_all.index.strftime('%Y-%m').isin(months_set)
+    return df_all.loc[mask].copy()
+
+
+def run_walkforward(cfg: dict, symbol: str, train: int, test: int, step: int):
+    df_all = load_symbol_1m(cfg['paths']['inputs_dir'], symbol, cfg['months'], progress=cfg['logging']['progress'])
+    folds = split_months(cfg['months'], train, test, step)
+    results = []
+    base_out = os.path.join(cfg['paths']['outputs_dir'], 'wf', symbol)
+    for k, f in enumerate(folds, start=1):
+        m_train, m_test = f['train'], f['test']
+        df_train = df_for_months(df_all, m_train)
+        df_test = df_for_months(df_all, m_test)
+        if df_train.empty or df_test.empty:
+            continue
+        df_fold = pd.concat([df_train, df_test]).sort_index()
+        start_ts = df_test.index[0]
+        cfg_fold = deepcopy(cfg)
+        outdir = os.path.join(base_out, f'fold_{k:03d}')
+        cfg_fold['paths']['outputs_dir'] = outdir
+        os.makedirs(outdir, exist_ok=True)
+        s = run_for_symbol(cfg_fold, symbol, progress_hook=None, df1m_override=df_fold, trade_start_ts=start_ts)
+        base = f"{symbol}_fold_{k:03d}_{m_train[0]}..{m_train[-1]}_{m_test[0]}..{m_test[-1]}"
+        tr_path = os.path.join(outdir, f"{symbol}_trades.csv")
+        if os.path.exists(tr_path):
+            os.rename(tr_path, os.path.join(outdir, f"{base}_trades.csv"))
+        sum_path = os.path.join(outdir, f"{symbol}_summary.json")
+        if os.path.exists(sum_path):
+            os.rename(sum_path, os.path.join(outdir, f"{base}_summary.json"))
+        s.update({
+            'fold_id': k,
+            'train_months': m_train,
+            'test_months': m_test,
+            'trade_start_ts': start_ts.isoformat(),
+            'bars_train': int(len(df_train)),
+            'bars_test': int(len(df_test)),
+        })
+        results.append(s)
+        print(f"FOLD {k:03d} [train: {m_train[0]}..{m_train[-1]} | test: {m_test[0]}] → trades={s.get('trades',0)}, sum_R={s.get('sum_R',0):.2f}, win_rate={s.get('win_rate',0):.2%}")
+    agg_keys = ['sum_r_sl', 'sum_r_be', 'sum_r_tsl', 'sum_r_sl_overshoot', 'sum_r_realized', 'SL_count', 'BE_count', 'TSL_count', 'trades']
+    aggregate = {k: 0.0 for k in agg_keys}
+    aggregate['SL_count'] = 0
+    aggregate['BE_count'] = 0
+    aggregate['TSL_count'] = 0
+    aggregate['trades'] = 0
+    win_acc = 0.0
+    avg_acc = 0.0
+    for r in results:
+        for k in agg_keys:
+            if k in r:
+                aggregate[k] += r.get(k, 0.0)
+        win_acc += r.get('win_rate', 0.0) * r.get('trades', 0)
+        avg_acc += r.get('avg_R', 0.0) * r.get('trades', 0)
+    tot = aggregate.get('trades', 0)
+    if tot > 0:
+        aggregate['win_rate'] = win_acc / tot
+        aggregate['avg_R'] = avg_acc / tot
+    else:
+        aggregate['win_rate'] = 0.0
+        aggregate['avg_R'] = 0.0
+    with open(os.path.join(base_out, 'aggregate.json'), 'w') as f:
+        json.dump({'folds': results, 'aggregate': aggregate}, f, indent=2)
+    return results


### PR DESCRIPTION
## Summary
- add warm-start and trade boundary support in backtester
- introduce walk-forward runner and aggregation helpers
- extend CLI with OOS and walk-forward modes and config options

## Testing
- `python -m run_backtest --config configs/default.yaml --workers 1`
- `python -m run_backtest --config configs/default.yaml --oos_last_k_months 2` *(fails: No monthly files found for BTCUSDT)*
- `python -m run_backtest --config configs/default.yaml --walkforward "train=3,test=1,step=1"` *(fails: No monthly files found for BTCUSDT)*

------
https://chatgpt.com/codex/tasks/task_e_68aee8d31ec4832b8c21efeaf48f46f3